### PR TITLE
Correct strings in list

### DIFF
--- a/json_to_csv/json_to_csv.py
+++ b/json_to_csv/json_to_csv.py
@@ -70,6 +70,9 @@ def _flatten(d, parent_key='', sep='_', int_to_float=False):
                 my_elems_w = []
                 if isinstance(w, dict):
                     my_elems_w.extend(_flatten(w, sep=sep, int_to_float=int_to_float).items())
+                elif isinstance(w, str):
+                    my_elems.append('"' + w + '"')
+                    continue
                 else:
                     my_elems.append(w)
                     continue


### PR DESCRIPTION
Previously, strings in list were converted to string of a list.

Example:
```
['test@test.fr'] ===> '[test@test.fr]'
```

This fixes this issues and keep strings inside lists as strings