### PR TITLE
Fix json array parser

### DIFF
--- a/json_to_csv/json_to_csv.py
+++ b/json_to_csv/json_to_csv.py
@@ -85,27 +85,9 @@ def _flatten(d, parent_key='', sep='_', int_to_float=False, remove_null=False):
                     continue
                 # Put in in alphabetical order
                 my_elems_w = sorted(my_elems_w, key=lambda tup: tup[0])
+                my_elems.append(dict(my_elems_w))
 
-                # For List build a string
-                dict_sorted = '{'
-                my_elems_w_order = OrderedDict(my_elems_w)
-                i = 0
-                for w_k, w_v in my_elems_w_order.items():
-                    if i!= 0:
-                        dict_sorted += ', '
-                    if isinstance(w_v, str):
-                        dict_sorted += '"{}": "{}"'.format(w_k, w_v)
-                    elif isinstance(w_v, int) and int_to_float:
-                        dict_sorted += '"{}": {}'.format(w_k, float(w_v))
-                    else:
-                        dict_sorted += '"{}": {}'.format(w_k, w_v)
-                    i += 1
-                dict_sorted += '}'
-
-                my_elems.append(dict_sorted)
-
-            my_elems = '[' + ','.join(my_elems) + ']'
-            items.append((new_key, my_elems))          
+            items.append((new_key, my_elems))      
         elif isinstance(v, dict):
             items.extend(_flatten(v, new_key, sep=sep, int_to_float=int_to_float, remove_null=remove_null).items())
         else:


### PR DESCRIPTION
Fix #14 

The same example now outputs
```
"[{'field_1': [{'subfield_1': 'test_1'}, {'subfield_1': 'test_2'}], 'field_2.subfield_2': 'test_3'}]" 
```

Note that now the fields are not in alphabetical order except if python > 3.6 where dict keep order of insertion.